### PR TITLE
Slight modification to use the whole Dataset instead of DefaultModel

### DIFF
--- a/rdfutils-jena/src/main/java/info/marcobrandizi/rdfutils/jena/TDBEndPointHelper.java
+++ b/rdfutils-jena/src/main/java/info/marcobrandizi/rdfutils/jena/TDBEndPointHelper.java
@@ -102,8 +102,8 @@ public class TDBEndPointHelper extends SparqlEndPointHelper implements AutoClose
 	@Override
 	public QueryExecution getQueryExecutor ( Query query )
 	{
-		Model m = this.getDataSet ().getDefaultModel ();
-		return QueryExecutionFactory.create ( query, m );
+//		Model m = this.getDataSet ().getDefaultModel ();
+		return QueryExecutionFactory.create ( query, this.getDataSet() );
 	}
 	
 	/**


### PR DESCRIPTION
This would be required to make the TDBEndPointHelper aware of the whole dataset instead of only the defaultModel. It is required because in the end it's calling to super.xxx to execute the actual queries, which in turn relies on the abstract method getQueryExecutor. 

This modification is required by rdf2neo project in order to enable the usage of GRAPH ?x and FROM ... clauses in the queries. 